### PR TITLE
Conditional imports to support operating with `pydantic>2` installed

### DIFF
--- a/prefect_twitter/credentials.py
+++ b/prefect_twitter/credentials.py
@@ -37,16 +37,16 @@ class TwitterCredentials(Block):
     _documentation_url = "https://prefecthq.github.io/prefect-twitter/credentials/#prefect_twitter.credentials.TwitterCredentials"  # noqa
 
     consumer_key: str = Field(
-        default=..., description="Twitter App API key used for authentication."
+        ..., description="Twitter App API key used for authentication."
     )
     consumer_secret: SecretStr = Field(
-        defualt=..., description="Twitter App API secret used for authentication."
+        ..., description="Twitter App API secret used for authentication."
     )
     access_token: str = Field(
-        default=..., description="Oauth token used to access the Twitter API."
+        ..., description="Oauth token used to access the Twitter API."
     )
     access_token_secret: SecretStr = Field(
-        default=..., description="Ouath secret used to access the Twitter API."
+        ..., description="Ouath secret used to access the Twitter API."
     )
 
     def get_api(self) -> API:

--- a/prefect_twitter/credentials.py
+++ b/prefect_twitter/credentials.py
@@ -1,7 +1,13 @@
 """Credential classes used to perform authenticated interactions with Twitter"""
 
 from prefect.blocks.core import Block
-from pydantic import Field, SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, SecretStr
+else:
+    from pydantic import Field, SecretStr
+
 from tweepy import API, OAuth1UserHandler
 
 


### PR DESCRIPTION
Following the compatibility work we've done in `prefect`, we also want to apply the
same compatibility changes to all Prefect-maintained collections.  We're following the
convention that Prefect will always use `pydantic<2` idioms, leaning on the
`pydantic.v1` module of `pydantic>2` to aid us in this.  With these changes, we can
operate normally regardless of the installed version.

Until `prefect` fully deprecates `pydantic` versions below 2.0, we'll continue to
maintain that constraint of using only v1 idioms.

This is part of a series of identical PRs for all of our maintained collections.